### PR TITLE
Add the possibility to build a snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 .mypy_cache/
 
 .DS_Store
+
+# Snapcraft
+*.snap

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pip>=10
-pyyaml
+pyyaml<=4.2,>=3.0
 async-timeout==2.0.1
 tox>=3.3
 juju>=0.10.2

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ SETUP = {
         "Environment :: Console"
     ],
     'install_requires': [
-        'pyyaml',
+        'pyyaml<=4.2,>=3.0',
         'async-timeout==2.0.1',
         'juju>=0.10.2',
         'argcomplete',

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: jujuna
+base: core18
+version: '0.1.5'
+summary: Jujuna, continuous deployment, upgrade and testing for Juju.
+description: |
+  Jujuna, continuous deployment, upgrade and testing for Juju.
+
+grade: devel
+confinement: strict
+
+parts:
+  jujuna:
+    plugin: python
+    python-version: python3
+    requirements:
+      - ./requirements.txt
+    source: .
+apps:
+  jujuna:
+    command: bin/jujuna
+    plugs:
+      - network
+      - home

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,8 +12,7 @@ parts:
   jujuna:
     plugin: python
     python-version: python3
-    requirements:
-      - ./requirements.txt
+    requirements: ./requirements.txt
     source: .
 apps:
   jujuna:


### PR DESCRIPTION
* Create the initial snapcraft file
* Ensure, both in `requirements.txt` and `setup.py`, that the version of
pyyaml is constrained.

It is then possible to build a snap of `jujuna` by running:
```bash
snapcraft
```
And to install it with:
```bash
sudo snap install jujuna_0.1.5_amd64.snap --dangerous
```
The `dangerous` flag is necessary to install locally generated snaps.

It is also possible to push this [snap to the snap store](https://docs.snapcraft.io/releasing-your-app/6795).